### PR TITLE
Show more items in sub-menu

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3,9 +3,13 @@
     "message": "Undo Close Tab",
     "description": "Name of the extension."
   },
-
   "extensionDescription": {
     "message": "Reopens the last closed tab.",
     "description": "Description of the extension."
+  },
+
+  "more_entries_menu": {
+    "message": "* More entries",
+    "description": "Last menu on Context menus of the browser action, as the top-level menu cannot exceed 6 items."
   }
 }

--- a/background.js
+++ b/background.js
@@ -44,14 +44,28 @@ async function ToolbarButtonClicked() {
 async function ClosedTabListChanged() {
   await browser.contextMenus.removeAll();
   const tabs = await GetLastClosedTabs();
-  tabs.forEach((closedTab) => {
+  tabs.splice(0, 5).forEach((closedTab) => { // top-level menu cannot exceed 6 items.
     let tab = closedTab.tab; // stripping "lastModified"
     browser.contextMenus.create({
       id: tab.sessionId,
       title: tab.title,
       contexts: ["browser_action"]
     });
-  })
+  });
+  let moreMenu = browser.contextMenus.create({
+    id: "MoreClosedTabs",
+    title: "* More entries",
+    contexts: ["browser_action"]
+  });
+  tabs.forEach((closedTab) => {
+    let tab = closedTab.tab;
+    browser.contextMenus.create({
+      id: tab.sessionId,
+      title: tab.title,
+      parentId: moreMenu,
+      contexts: ["browser_action"]
+    });
+  });
 }
 
 // Fired if one of our context menu entries is clicked.

--- a/background.js
+++ b/background.js
@@ -54,7 +54,7 @@ async function ClosedTabListChanged() {
   });
   let moreMenu = browser.contextMenus.create({
     id: "MoreClosedTabs",
-    title: "* More entries",
+    title: browser.i18n.getMessage("more_entries_menu"),
     contexts: ["browser_action"]
   });
   tabs.forEach((closedTab) => {

--- a/background.js
+++ b/background.js
@@ -1,6 +1,7 @@
 /*
     Firefox addon "Undo Close Tab"
     Copyright (C) 2017  Manuel Reimer <manuel.reimer@gmx.de>
+    Copyright (C) 2017  YFdyh000 <yfdyh000@gmail.com>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -16,50 +17,41 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-// Function to do all this "Promise" stuff required by the webextensions API.
+// Function to do all this "Promise" stuff required by the WebExtensions API.
 // Will finally call the supplied callback with a list of closed tabs.
-function GetLastClosedTabs(aCallback) {
-  browser.windows.getCurrent().then(
-    function(CurrentWindow) {
-      browser.sessions.getRecentlyClosed().then(
-        function(Sessions) {
-          var tablist = [];
-          for (var index = 0; index < Sessions.length; index++) {
-            var session = Sessions[index];
-            if (session.tab &&
-                session.tab.windowId == CurrentWindow.id)
-              tablist.push(session.tab);
-          }
-          aCallback(tablist);
-        }, onError
-      );
-    }, onError
-  );
+async function GetLastClosedTabs() {
+  try {
+    const currentWindow = await browser.windows.getCurrent();
+    const sessions = await browser.sessions.getRecentlyClosed();
+    let tabs = sessions.filter((s) => (s.tab && s.tab.windowId === currentWindow.id));
+    return tabs;
+  } catch (error) {
+    // Simple error handler. Just logs the error to console.
+    console.log(error);
+  }
 }
 
 // Fired if the toolbar button is clicked.
 // Restores the last closed tab in list.
-function ToolbarButtonClicked() {
-  GetLastClosedTabs(function(tablist) {
-    if (tablist.length > 0)
-      browser.sessions.restore(tablist[0].sessionId);
-  });
+async function ToolbarButtonClicked() {
+  const tabs = await GetLastClosedTabs();
+  if (tabs.length > 0)
+    await browser.sessions.restore(tabs[0].sessionId);
 }
 
 // Fired if the list of closed tabs has changed.
 // Updates the context menu entries with the list of last closed tabs.
-function ClosedTabListChanged() {
-  browser.contextMenus.removeAll();
-  GetLastClosedTabs(function(tablist) {
-    for (var index = 0; index < tablist.length; index++) {
-      var tab = tablist[index];
-      browser.contextMenus.create({
-        id: tab.sessionId,
-        title: tab.title,
-        contexts: ["browser_action"]
-      });
-    }
-  });
+async function ClosedTabListChanged() {
+  await browser.contextMenus.removeAll();
+  const tabs = await GetLastClosedTabs();
+  tabs.forEach((closedTab) => {
+    let tab = closedTab.tab; // stripping "lastModified"
+    browser.contextMenus.create({
+      id: tab.sessionId,
+      title: tab.title,
+      contexts: ["browser_action"]
+    });
+  })
 }
 
 // Fired if one of our context menu entries is clicked.
@@ -67,12 +59,6 @@ function ClosedTabListChanged() {
 function ContextMenuClicked(aInfo) {
   browser.sessions.restore(aInfo.menuItemId);
 }
-
-// Simple error handler. Just logs the error to console.
-function onError(error) {
-  console.log(error);
-}
-
 
 // Register event listeners
 browser.browserAction.onClicked.addListener(ToolbarButtonClicked);


### PR DESCRIPTION
I guess this requires an explanation on extension detail page.

Free to merge, which will has conflict with other pull requests.

https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/contextMenus/ContextType

> browser_action
>    Applies when the user context-clicks your browser action. You can only add 6 items to the top-level context menu, but can add submenus.

https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/sessions/MAX_SESSION_RESULTS

> It is read-only for WebExtension code, and is set to 25.