### PR TITLE
sessions.onChanged needs Firefox 53

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   "applications": {
     "gecko": {
       "id": "{4853d046-c5a3-436b-bc36-220fd935ee1d}",
-      "strict_min_version": "52.0"
+      "strict_min_version": "53.0"
     }
   },
 


### PR DESCRIPTION
Firefox 52 ESR not work. `TypeError: browser.sessions.onChanged is undefined`

https://bugzilla.mozilla.org/show_bug.cgi?id=1320306