### PR TITLE
add dark mode support for the options page

### DIFF
--- a/options.css
+++ b/options.css
@@ -1,0 +1,16 @@
+:root {
+  --page-bg-color: #fff;
+  --page-fg-color: #15141a;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page-bg-color: #23222b;
+    --page-fg-color: #fbfbfe;
+  }
+}
+
+body {
+  background-color: var(--page-bg-color);
+  color: var(--page-fg-color);
+}

--- a/options.html
+++ b/options.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <link rel="stylesheet" href="options.css">
   </head>
   <body>
     <form>


### PR DESCRIPTION
This is a small patch that change the text and background colors of the options page depending on the Firefox theme (dark/light) used. 

![undo-dark-mode](https://user-images.githubusercontent.com/7339076/155454326-8155f99a-7cde-45c1-8c23-4590fa3bcc7b.png)
