### PR TITLE
Added shortcut support Issue #115

### DIFF
--- a/background.js
+++ b/background.js
@@ -214,4 +214,16 @@ if (browser.menus !== undefined &&
 
 browser.browserAction.onClicked.addListener(ToolbarButtonClicked);
 
+// Listens for shortcuts referenced in manfest.json/commands and
+// fires appropriate function based on command string received
+browser.commands.onCommand.addListener(async (command) => {
+  switch (command) {
+    case "activate-undo":
+      await ToolbarButtonClicked();
+      break;
+    default:
+      console.log("No action defined for supported shortcut");
+  }
+});
+
 IconUpdater.Init("icons/undoclosetab.svg");

--- a/manifest.json
+++ b/manifest.json
@@ -51,5 +51,14 @@
     "theme"
   ],
 
-  "default_locale": "en"
+  "default_locale": "en",
+
+  "commands": {
+    "activate-undo": {
+      "suggested_key": {
+        "default": "Ctrl+Alt+Z"
+      },
+      "description": "Activate the Undo Command"
+    }
+  }
 }


### PR DESCRIPTION
Related Issue: #115 
## Changes Made
- added a `commands` key object to `manifest.json` for the new shortcut
- added a new listener to `background.js` (`browser.commands.onCommand.addListener`) to activate the `ToolbarButtonClicked` function when activated.

Implementation was tested in the Firefox Extension debugger and worked as intended:
1. Shortcut verified working (Ctrl+Alt+Z)
2. Shortcut now appears under **Undo Close Tab** in **Settings** > **Extensions** > **Manage Your Extensions** > ⚙> **Manage Extension Shortcuts**